### PR TITLE
[flutter] 바코드 입력 페이지 구현

### DIFF
--- a/store/ios/Podfile.lock
+++ b/store/ios/Podfile.lock
@@ -3,6 +3,8 @@ PODS:
     - Flutter
     - ReachabilitySwift
   - Flutter (1.0.0)
+  - flutter_keyboard_visibility (0.0.1):
+    - Flutter
   - path_provider_ios (0.0.1):
     - Flutter
   - ReachabilitySwift (5.0.0)
@@ -12,6 +14,7 @@ PODS:
 DEPENDENCIES:
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
   - Flutter (from `Flutter`)
+  - flutter_keyboard_visibility (from `.symlinks/plugins/flutter_keyboard_visibility/ios`)
   - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
   - webview_flutter_wkwebview (from `.symlinks/plugins/webview_flutter_wkwebview/ios`)
 
@@ -24,6 +27,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/connectivity_plus/ios"
   Flutter:
     :path: Flutter
+  flutter_keyboard_visibility:
+    :path: ".symlinks/plugins/flutter_keyboard_visibility/ios"
   path_provider_ios:
     :path: ".symlinks/plugins/path_provider_ios/ios"
   webview_flutter_wkwebview:
@@ -32,6 +37,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   connectivity_plus: 413a8857dd5d9f1c399a39130850d02fe0feaf7e
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   path_provider_ios: 7d7ce634493af4477d156294792024ec3485acd5
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   webview_flutter_wkwebview: 005fbd90c888a42c5690919a1527ecc6649e1162

--- a/store/lib/src/adapter/presentation/common/custom/bottom_navi/custom_bottom_navigator.dart
+++ b/store/lib/src/adapter/presentation/common/custom/bottom_navi/custom_bottom_navigator.dart
@@ -36,7 +36,7 @@ class CustomBottomBar extends StatefulWidget {
 }
 
 class _CustomBottomBarState extends State<CustomBottomBar> {
-  final double tabWidth = Get.width * 0.15;
+  final double tabWidth = Get.width * 0.16;
 
   int currentIndex = 0;
 
@@ -95,7 +95,7 @@ class _CustomBottomBarState extends State<CustomBottomBar> {
                     },
                   ),
                   Container(
-                    width: tabWidth,
+                    width: Get.width * 0.15,
                   ),
                   _TabItem(
                     minWidth: tabWidth,

--- a/store/lib/src/adapter/presentation/modules/barcode/model/mobile_carrier.dart
+++ b/store/lib/src/adapter/presentation/modules/barcode/model/mobile_carrier.dart
@@ -1,0 +1,9 @@
+class MobileCarrier {
+  final int index;
+  final String name;
+
+  MobileCarrier({
+    required this.index,
+    required this.name,
+  });
+}

--- a/store/lib/src/adapter/presentation/modules/barcode/widget/barcode_bottom_sheet.dart
+++ b/store/lib/src/adapter/presentation/modules/barcode/widget/barcode_bottom_sheet.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../store_root/controller/store_root_controller.dart';
+
+class BarcodeBottomSheet extends GetWidget<StoreRootController> {
+  final Widget child;
+  final double height;
+
+  const BarcodeBottomSheet({
+    Key? key,
+    required this.child,
+    required this.height,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    if (kDebugMode) {
+      return _createContents(context);
+    } else {
+      return BackButtonListener(
+        child: _createContents(context),
+        onBackButtonPressed: () {
+          var preShowBarcode = controller.showBarcode.value;
+          controller.showBarcode(false);
+
+          return Future.value(preShowBarcode);
+        },
+      );
+    }
+  }
+
+  Obx _createContents(BuildContext context) {
+    return Obx(
+      () {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            GestureDetector(
+              onTap: () {
+                controller.showBarcode.toggle();
+
+                var currentFocus = FocusScope.of(context);
+
+                if (!currentFocus.hasPrimaryFocus && currentFocus.hasFocus) {
+                  FocusManager.instance.primaryFocus?.unfocus();
+                }
+              },
+              child: Visibility(
+                visible: controller.showBarcode.value,
+                child: Container(
+                  color: Colors.black.withOpacity(0.5),
+                  width: Get.width,
+                  height: Get.height,
+                ),
+              ),
+            ),
+            AnimatedPositioned(
+              bottom: controller.showBarcode.value ? 0 : -(height),
+              right: 0.0,
+              left: 0.0,
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.only(
+                    topRight: Radius.circular(20.0),
+                    topLeft: Radius.circular(20.0),
+                  ),
+                ),
+                width: Get.width,
+                height: height,
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 8.0),
+                      child: Container(
+                        width: 60,
+                        height: 5,
+                        decoration: BoxDecoration(
+                            color: Colors.grey[400],
+                            borderRadius:
+                                BorderRadius.all(Radius.circular(20))),
+                      ),
+                    ),
+                    Expanded(child: child),
+                  ],
+                ),
+              ),
+              duration: Duration(milliseconds: 300),
+              curve: Curves.decelerate,
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/store/lib/src/adapter/presentation/modules/barcode/widget/mobile_carrier_tab_item.dart
+++ b/store/lib/src/adapter/presentation/modules/barcode/widget/mobile_carrier_tab_item.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+import '../model/mobile_carrier.dart';
+
+class MobileCarrierTabItem extends StatelessWidget {
+  final MobileCarrier carrier;
+  final double width;
+  final double height;
+  final Color color;
+  final ValueChanged<int>? onTap;
+  final TextStyle textStyle;
+
+  const MobileCarrierTabItem({
+    Key? key,
+    required this.carrier,
+    required this.width,
+    this.height = 30,
+    required this.color,
+    required this.onTap,
+    required this.textStyle,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        if (onTap != null) {
+          onTap!(carrier.index);
+        }
+        ;
+      },
+      child: Container(
+        width: width,
+        height: height,
+        decoration: BoxDecoration(
+          border: Border.all(
+            width: 1.5,
+            color: color,
+          ),
+          borderRadius: BorderRadius.circular(5),
+        ),
+        child: Center(
+          child: Text(
+            carrier.name,
+            style: textStyle.copyWith(color: color),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/store/lib/src/adapter/presentation/modules/store_root/controller/store_root_controller.dart
+++ b/store/lib/src/adapter/presentation/modules/store_root/controller/store_root_controller.dart
@@ -1,5 +1,48 @@
+import 'dart:async';
+
+import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:get/get.dart';
 
+import '../../barcode/model/mobile_carrier.dart';
+
 class StoreRootController extends GetxController {
-  RxBool showBarcode = false.obs;
+  final RxBool showBarcode = false.obs;
+  final RxInt selectedCarrierIndex = 0.obs;
+  final RxBool _showBottomNavigator = true.obs;
+  late final StreamSubscription<bool> _keyboardSubscription;
+
+  @override
+  void onInit() {
+    super.onInit();
+    var keyboardVisibilityController = KeyboardVisibilityController();
+    _keyboardSubscription =
+        keyboardVisibilityController.onChange.listen((visible) {
+      _showBottomNavigator(!visible);
+    });
+  }
+
+  @override
+  void onClose() {
+    _keyboardSubscription.cancel();
+  }
+
+  bool get showBottomNavigator => _showBottomNavigator.value;
+
+  String get selectedCarrierName =>
+      mobileCarriers[selectedCarrierIndex.value].name;
+
+  final List<MobileCarrier> mobileCarriers = [
+    MobileCarrier(
+      index: 0,
+      name: 'SKT',
+    ),
+    MobileCarrier(
+      index: 1,
+      name: 'KT',
+    ),
+    MobileCarrier(
+      index: 2,
+      name: 'LGU+',
+    ),
+  ];
 }

--- a/store/lib/src/application/barcode/service/Barcode_formatter.dart
+++ b/store/lib/src/application/barcode/service/Barcode_formatter.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/services.dart';
+
+class BarcodeInputFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(
+      TextEditingValue oldValue, TextEditingValue newValue) {
+    var text = newValue.text;
+
+    if (newValue.selection.baseOffset == 0) {
+      return newValue;
+    }
+
+    var buffer = StringBuffer();
+    for (var i = 0; i < text.length; i++) {
+      buffer.write(text[i]);
+      var nonZeroIndex = i + 1;
+      if (nonZeroIndex % 4 == 0 && nonZeroIndex != text.length) {
+        // Replace this with anything you want to put after each 4 numbers
+        buffer.write(' ');
+      }
+    }
+
+    var string = buffer.toString();
+
+    return newValue.copyWith(
+      text: string,
+      selection: TextSelection.collapsed(offset: string.length),
+    );
+  }
+}

--- a/store/lib/src/common/message/messages.dart
+++ b/store/lib/src/common/message/messages.dart
@@ -5,4 +5,7 @@ abstract class Messages {
   static const String pbProduct = 'PB 상품';
   static const String map = '지도';
   static const String favoriteProduct = '찜한 상품';
+  static const String membershipTitle = '나의 멤버십';
+  static const String membership = '멤버십';
+  static const String inputMembershipCode = '멤버십 번호를 입력하세요';
 }

--- a/store/pubspec.lock
+++ b/store/pubspec.lock
@@ -29,6 +29,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.8.2"
+  barcode:
+    dependency: transitive
+    description:
+      name: barcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.0"
+  barcode_widget:
+    dependency: "direct main"
+    description:
+      name: barcode_widget
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -272,6 +286,27 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_keyboard_visibility:
+    dependency: "direct main"
+    description:
+      name: flutter_keyboard_visibility
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.1.0"
+  flutter_keyboard_visibility_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  flutter_keyboard_visibility_web:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -534,6 +569,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  qr:
+    dependency: transitive
+    description:
+      name: qr
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.0"
   responsive_framework:
     dependency: "direct main"
     description:

--- a/store/pubspec.yaml
+++ b/store/pubspec.yaml
@@ -27,6 +27,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
+  barcode_widget: ^2.0.2
   connectivity_plus: ^2.1.0
   cupertino_icons: ^1.0.2
   effective_dart: ^1.3.2
@@ -34,6 +35,7 @@ dependencies:
   flex_color_scheme: ^4.1.1
   flutter:
     sdk: flutter
+  flutter_keyboard_visibility: ^5.1.0
   get: ^4.6.1
   google_fonts: ^2.1.0
   json_annotation: ^4.4.0


### PR DESCRIPTION
* 화면 껍데기 구현.
* 키보드가 표시되면 하단 네비는 사라짐 구현
* 바코드 입력 textfield 관련 내용 구현
    * 숫자만 가능
    * 4자리 입력 후, 공백 자동 추가
* 백버튼 누르면 활성화된 페이지가 닫히도록 구현